### PR TITLE
docs: fix notes about other integrations

### DIFF
--- a/docs/src/main/asciidoc/spanner.adoc
+++ b/docs/src/main/asciidoc/spanner.adoc
@@ -960,7 +960,7 @@ This feature requires a bean of `SpannerTransactionManager`, which is provided w
 If a method annotated with `@Transactional` calls another method also annotated, then both methods will work within the same transaction.
 `performReadOnlyTransaction` and `performReadWriteTransaction` cannot be used in `@Transactional` annotated methods because Cloud Spanner does not support transactions within transactions.
 
-Other Google Cloud database-related integrations like Spanner and Firestore can introduce `PlatformTransactionManager` beans, and can interfere with Datastore Transaction Manager. To disambiguate, explicitly specify the name of the transaction manager bean for such `@Transactional` methods. Example:
+Other Google Cloud database-related integrations like Firestore can introduce `PlatformTransactionManager` beans, and can interfere with Spanner Transaction Manager. To disambiguate, explicitly specify the name of the transaction manager bean for such `@Transactional` methods. Example:
 
 [source,java]
 ----


### PR DESCRIPTION
The original text says:

> Other Google Cloud database-related integrations like Spanner and Firestore can introduce `PlatformTransactionManager` …

However, the docs _are_ about Spanner integration.
